### PR TITLE
docs: add direct links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 **I'm a software engineer passionate about developer experience and automation** 👨🏻‍💻
 
-- Currently on Developer Experience at [Podium](@podium), formerly DevEx at [Embark Trucks](@embarktrucks) :truck:
+- Currently on Developer Experience at [Podium](https://github.com/podium), formerly DevEx at [Embark Trucks](https://github.com/embarktrucks) :truck:
 - Based outside of Los Angeles, CA :ocean::sunny:


### PR DESCRIPTION
The @-mention doesn't seem to work in a profile README, for some reason, so adding an explicit URL un-404s these.